### PR TITLE
Moving local postgres port to 5434 to mesh with fictiv-made locadev

### DIFF
--- a/13.0/docker-compose.yml
+++ b/13.0/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   db:
     image: 754040250767.dkr.ecr.us-west-2.amazonaws.com/odoodb0-dev1-or0 # postgres:10
     ports:
-      - "5432:5432" # exposing this out properly to connect with local client
+      - "5434:5432" # exposing this out properly to connect with local client
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_PASSWORD=odoo
@@ -29,7 +29,7 @@ services:
   redis:
     image: bitnami/redis:latest
     ports:
-      - "6379:6379"
+      - "6380:6379"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
 volumes:


### PR DESCRIPTION
Without this edit, fictiv-made localdev in vagrant and odoo docker localdev collide on postgres and redis ports. Since we need everything up, moving odoo postgres and redis ports up port or two (and leaving a port avail for the teams db if we ever segregate that from fictiv db for localdev in the future).